### PR TITLE
Extensions usability

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,7 +372,7 @@ extend google.protobuf.FileOptions {
 }
 ```
 
-You need to compile these definitions alone before your other protos. The above will generate const `Extension` fields `MY_OPT` and `MY_OPT_REPEATED` that you'll need to register in an `ExtensionRegistry` as well as request data from an `Extendable` message.
+You need to compile these definitions alone before your other protos. The above will generate const `Extension` fields `MY_OPT` and `MY_REPEATED_OPT` that you'll need to register in an `ExtensionRegistry` as well as request data from an `Extendable` message.
 
 ### Setting Option Data in Proto Files
 
@@ -397,7 +397,7 @@ mod custom_options {
 fn generate() {
     let mut extension_registry = ExtensionRegistry::new();
     extension_registry.register(custom_options::MY_OPT); // const Extension definitions.
-    extension_registry.register(custom_options::MY_OPT_REPEATED);
+    extension_registry.register(custom_options::MY_REPEATED_OPT);
     let descriptor_set: FileDescriptorSet = Message::decode_with_extensions(DESCRIPTOR_SET_BYTES, extension_registry);
     for file in descriptor_set.file {
         println!("file {} my_opt: {:?}", file.name.unwrap(),
@@ -405,7 +405,7 @@ fn generate() {
                  file.options.extension_data(&custom_options::MY_OPT));
         println!("file {} my_opt: {:?}", file.name.unwrap(),
                  // Returns an Option<Vec<String>> (based on our Extension declared above).
-                 file.options.extension_data(&custom_options::MY_OPT_REPEATED));
+                 file.options.extension_data(&custom_options::MY_REPEATED_OPT));
     }
 }
 ```

--- a/prost-build/src/code_generator.rs
+++ b/prost-build/src/code_generator.rs
@@ -364,9 +364,9 @@ impl<'a> CodeGenerator<'a> {
         self.push_indent();
         self.buf.push_str("pub const ");
         self.buf.push_str(&extension.name().to_ascii_uppercase());
-        self.buf.push_str(" : ::prost::ExtensionImpl<");
+        self.buf.push_str(": &::prost::ExtensionImpl<");
         append_field_type(self.buf);
-        self.buf.push_str("> = ::prost::ExtensionImpl::<");
+        self.buf.push_str("> = &::prost::ExtensionImpl::<");
         append_field_type(self.buf);
         self.buf.push_str("> { extendable_type_id: \"");
         self.buf.push_str(&extendee);

--- a/tests/src/custom_options.proto
+++ b/tests/src/custom_options.proto
@@ -11,6 +11,7 @@ message CustomOptionType {
 }
 
 extend google.protobuf.FileOptions {
+    // A basic file option for a double
     double file_opt_double = 50000;
     float file_opt_float = 50001;
     int32 file_opt_int32 = 50002;
@@ -120,6 +121,7 @@ extend google.protobuf.EnumValueOptions {
 
 message NestedOptions {
     extend google.protobuf.MessageOptions {
+        // A nested extension
         string nested_opt = 50001;
     }
 }

--- a/tests/src/custom_options.rs
+++ b/tests/src/custom_options.rs
@@ -21,7 +21,7 @@ macro_rules! test_custom_option {
     ($test_name: ident, $extension: expr, $expected: expr) => {
         #[test]
         fn $test_name() {
-            run_test(&$extension, $expected)
+            run_test($extension, $expected)
         }
     };
 }
@@ -224,7 +224,7 @@ mod message {
 
 #[test]
 fn field() {
-    let extension = &custom_options::FIELD_OPT;
+    let extension = custom_options::FIELD_OPT;
     let file_descriptor_set = load_desc_set(extension);
     let test_msg = find_test_msg(&file_descriptor_set);
     let field = test_msg
@@ -242,7 +242,7 @@ fn field() {
 
 #[test]
 fn oneof() {
-    let extension = &custom_options::ONEOF_OPT;
+    let extension = custom_options::ONEOF_OPT;
     let file_descriptor_set = load_desc_set(extension);
     let test_msg = find_test_msg(&file_descriptor_set);
     assert_eq!(test_msg.oneof_decl.len(), 1);
@@ -257,7 +257,7 @@ fn oneof() {
 
 #[test]
 fn enum_opt() {
-    let extension = &custom_options::ENUM_OPT;
+    let extension = custom_options::ENUM_OPT;
     let file_descriptor_set = load_desc_set(extension);
     let test_enum = find_test_enum(&file_descriptor_set);
     let enum_options = test_enum.options.as_ref().expect("Enum has no options");
@@ -270,7 +270,7 @@ fn enum_opt() {
 
 #[test]
 fn enum_value() {
-    let extension = &custom_options::ENUM_VALUE_OPT;
+    let extension = custom_options::ENUM_VALUE_OPT;
     let file_descriptor_set = load_desc_set(extension);
     let test_enum = find_test_enum(&file_descriptor_set);
     let enum_value = test_enum.value.get(0).expect("Enum value missing.");

--- a/tests/src/custom_options.rs
+++ b/tests/src/custom_options.rs
@@ -286,6 +286,44 @@ fn enum_value() {
     assert_eq!(ext_data, &"hello");
 }
 
+#[test]
+fn register_extensions() {
+    let mut extension_registry = ExtensionRegistry::new();
+    custom_options::register_extensions(&mut extension_registry);
+    custom_options_ext::register_extensions(&mut extension_registry);
+
+    let enum_value_opt = extension_registry.extension(
+        custom_options::ENUM_VALUE_OPT.extendable_type_id(),
+        custom_options::ENUM_VALUE_OPT.field_tag(),
+    );
+    assert!(matches!(enum_value_opt, Some(_)));
+
+    let message_opt_from_ext = extension_registry.extension(
+        custom_options_ext::MESSAGE_OPT_FROM_EXT.extendable_type_id(),
+        custom_options_ext::MESSAGE_OPT_FROM_EXT.field_tag(),
+    );
+    assert!(matches!(message_opt_from_ext, Some(_)));
+}
+
+#[test]
+fn register_message_extensions() {
+    let mut extension_registry = ExtensionRegistry::new();
+    custom_options::NestedOptions::register_extensions(&mut extension_registry);
+    custom_options_ext::NestedOptions::register_extensions(&mut extension_registry);
+
+    let nested_opt = extension_registry.extension(
+        custom_options::NestedOptions::NESTED_OPT.extendable_type_id(),
+        custom_options::NestedOptions::NESTED_OPT.field_tag(),
+    );
+    assert!(matches!(nested_opt, Some(_)));
+
+    let nested_opt_from_ext = extension_registry.extension(
+        custom_options_ext::NestedOptions::NESTED_OPT_FROM_EXT.extendable_type_id(),
+        custom_options_ext::NestedOptions::NESTED_OPT_FROM_EXT.field_tag(),
+    );
+    assert!(matches!(nested_opt_from_ext, Some(_)));
+}
+
 fn load_desc_set(extension_to_test: &'static dyn Extension) -> FileDescriptorSet {
     Message::decode_with_extensions(DESCRIPTOR_SET_BYTES, registry(extension_to_test))
         .expect("Failed to decode descriptor set")

--- a/tests/src/extensions.proto
+++ b/tests/src/extensions.proto
@@ -12,6 +12,7 @@ message ExtendableMessage {
 }
 
 extend ExtendableMessage {
+  // Double value extension
   optional double ext_double = 100;
   optional float ext_float = 101;
   optional int32 ext_int32 = 102;

--- a/tests/src/extensions.rs
+++ b/tests/src/extensions.rs
@@ -14,11 +14,11 @@ macro_rules! test_extension {
         fn $test_name() -> Result<(), DecodeError> {
             let mut message = extensions::ExtendableMessage::default();
             message
-                .set_extension_data(&$extension, $value)
+                .set_extension_data($extension, $value)
                 .expect("Failed to set ext data");
-            let message = roundtrip(&message, &$extension);
+            let message = roundtrip(&message, $extension);
             let ext_data = message
-                .extension_data(&$extension)
+                .extension_data($extension)
                 .expect("Failed to get ext data");
             assert_eq!(*ext_data, $value);
             Ok(())
@@ -151,11 +151,11 @@ fn clear_message_clears_ext_set() {
     let mut message = extensions::ExtendableMessage::default();
     let data = "data".to_string();
     message
-        .set_extension_data(&extensions::EXT_STRING, data.clone())
+        .set_extension_data(extensions::EXT_STRING, data.clone())
         .expect("Failed to set ext data");
-    assert_eq!(message.extension_data(&extensions::EXT_STRING), Ok(&data));
+    assert_eq!(message.extension_data(extensions::EXT_STRING), Ok(&data));
     message.clear();
-    assert!(message.extension_data(&extensions::EXT_STRING).is_err());
+    assert!(message.extension_data(extensions::EXT_STRING).is_err());
 }
 
 fn roundtrip<M>(message: &M, extension: &'static dyn Extension) -> M

--- a/tests/src/extensions.rs
+++ b/tests/src/extensions.rs
@@ -158,6 +158,18 @@ fn clear_message_clears_ext_set() {
     assert!(message.extension_data(extensions::EXT_STRING).is_err());
 }
 
+#[test]
+fn register_extensions() {
+    let mut extension_registry = ExtensionRegistry::new();
+    extensions::register_extensions(&mut extension_registry);
+
+    let enum_value_opt = extension_registry.extension(
+        extensions::EXT_MESSAGE_REPEATED.extendable_type_id(),
+        extensions::EXT_MESSAGE_REPEATED.field_tag(),
+    );
+    assert!(matches!(enum_value_opt, Some(_)));
+}
+
 fn roundtrip<M>(message: &M, extension: &'static dyn Extension) -> M
 where
     M: Message + Default,


### PR DESCRIPTION
Four commits aimed at improving the usability of the extensions PR (tokio-rs/prost#591)

The first just creates the extension constants as static references. This makes the constant itself a bit smaller and it fits better with the API, which generally is always asking for a reference.

The second adds a utility function to make it easy to register all extensions in a file and message. The file-level registration doesn't register all extensions for the messages below it right now, but that could be done if more desirable. The primary goal here is just to simplify the extension registration process.

The third commit attaches doc comments to the extension constants generated in code. So, if your option has some comments explaining what it is for, that will now appear in the documentation.

I also added a 4th commit consisting of my recommendations for typo fixes in the README on the main pull request.