### PR TITLE
Extensions no std

### DIFF
--- a/prost-build/src/code_generator.rs
+++ b/prost-build/src/code_generator.rs
@@ -401,6 +401,8 @@ impl<'a> CodeGenerator<'a> {
 
         self.append_doc(fq_message_name, extension.name.as_deref());
         self.push_indent();
+        self.buf.push_str("#[allow(clippy::redundant_static_lifetimes)]\n");
+        self.push_indent();
         self.buf.push_str("pub const ");
         self.buf.push_str(&extension.name().to_ascii_uppercase());
         self.buf.push_str(": &'static ::prost::ExtensionImpl<");

--- a/src/extension.rs
+++ b/src/extension.rs
@@ -1,3 +1,4 @@
+use crate::alloc::boxed::Box;
 use crate::alloc::collections::btree_map::Entry;
 use crate::alloc::collections::BTreeMap;
 use crate::alloc::fmt::{Display, Formatter};
@@ -618,11 +619,14 @@ fn registry_key(extension: &'static dyn Extension) -> RegistryKey {
 
 #[cfg(test)]
 mod tests {
+    use crate::alloc::boxed::Box;
+    use crate::alloc::string::{String, ToString};
     use crate::extension::{ExtendableTypeId, ExtensionValueImpl};
     use crate::{Extendable, ExtensionImpl, ExtensionSet, ExtensionValue, ProtoIntType};
     use core::marker::PhantomData;
 
     mod extension_value {
+        use crate::alloc::string::{String, ToString};
         use crate::extension::tests::{create_ext_value, create_ext_value_dyn};
         use crate::extension::ExtensionValueImpl;
 
@@ -681,6 +685,8 @@ mod tests {
     }
 
     mod extension_set {
+        use crate::alloc::boxed::Box;
+        use crate::alloc::string::ToString;
         use crate::extension::tests::{
             create_ext_value, TestExtendable, TEST_EXTENSION, TEST_EXTENSION_B,
         };
@@ -713,6 +719,7 @@ mod tests {
         }
 
         mod extension_data {
+            use crate::alloc::string::ToString;
             use crate::extension::tests::extension_set::create_test_extension_set;
             use crate::extension::tests::{OTHER_TEST_EXTENSION, TEST_EXTENSION, TEST_EXTENSION_B};
             use crate::extension::ExtensionSetError;

--- a/src/generic.rs
+++ b/src/generic.rs
@@ -1,5 +1,9 @@
 //! Types used for dynamically encoding to and merging from encoded protobuf binary data by delegating to the `crate::encoding` module.
 
+use alloc::format;
+use alloc::string::String;
+use alloc::vec::Vec;
+
 use bytes::{Buf, BufMut};
 
 use crate::bytes::buf::UninitSlice;


### PR DESCRIPTION
Noted that there were build failures with no-std, so I fixed those. Also added that Clippy lint for redundant static lifetimes as the simplest solution to the warnings.